### PR TITLE
Adding a generic test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 
 project(luxmart-attiny85)
 
-add_executable(${PROJECT_NAME}-test test.cpp)
+add_executable(${PROJECT_NAME}-test test/test.cpp)
 target_include_directories(${PROJECT_NAME}-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME}-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(luxmart-attiny85)
+
+add_executable(${PROJECT_NAME}-test test.cpp)
+target_include_directories(${PROJECT_NAME}-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/luxmart-attiny85.ino
+++ b/luxmart-attiny85.ino
@@ -73,8 +73,7 @@ void loop()
 			}
 			break;
 		case ReceiveValue:
-			value = rc;
-			value = *(reinterpret_cast<unsigned char*>(&value));
+			value = *(reinterpret_cast<unsigned char*>(&rc));
 			analogWrite(PWM_PIN, value);
 			// Value received; switc serial back to command mode.
 			mode = ReceiveCommand;

--- a/luxmart-attiny85.ino
+++ b/luxmart-attiny85.ino
@@ -6,38 +6,55 @@
 #define TX_PIN 3
 
 int value = 0;
+const int step = 10;
+
 SoftSerial serial(RX_PIN, TX_PIN);
 
 void setup()
 {
-    serial.begin(9600);
-    pinMode(PWM_PIN, OUTPUT);
-    analogWrite(PWM_PIN, value);
+  serial.begin(9600);
+  pinMode(PWM_PIN, OUTPUT);
+  analogWrite(PWM_PIN, value);
 }
 
 void loop()
 {
-    if (serial.available())
+  if (serial.available())
+  {
+    char rc = serial.read();
+    switch (rc)
     {
-        char rc = serial.read();
-        switch (rc)
-        {
-            case 'w':
-            value += step;
-            value = min(255, value);
-            analogWrite(PWM_PIN, value);
-
-            int newValue = serial.read();
-            if(0 < newValue && newValue < 255)
-                value = newValue;
-
-            analogWrite(PWM_PIN, value);
-            break;
-
-            case 'r':
-            serial.write('w');
-            serial.write(value);
-            break;
-        }
+      // Keys for incrementing and decrementing by a fixed step
+    case 'u' :
+      value += step;
+      value = min(255, value);
+      analogWrite(PWM_PIN, value);
+      break;
+    case 'd' :
+      value -= step;
+      value = max(0, value);
+      analogWrite(PWM_PIN, value);
+      break;
+      // Key for setting a specific value
+    case 'w':
+      value = serial.read();
+      value = *(reinterpret_cast<unsigned char*>(&value));
+      analogWrite(PWM_PIN, value);
+      break;
+      // Key for reading the value
+    case 'r':
+      serial.write('w');
+      serial.write(value);
+      break;
+      // Keys for setting to minimum and maximum value
+    case 'm' :
+      value = 255;
+      analogWrite(PWM_PIN, value);
+      break;
+    case '0' :
+      value = 0;
+      analogWrite(PWM_PIN, value);
+      break;
     }
+  }
 }

--- a/luxmart-attiny85.ino
+++ b/luxmart-attiny85.ino
@@ -5,17 +5,19 @@
 #define RX_PIN 1
 #define TX_PIN 3
 
+#define BAUD_RATE 9600
+
 int value = 0;
 const int step = 10;
 
 enum Command
 {
-  CommandStepUp = 'u',
-  CommandStepDown = 'd',
-  CommandSetValue = 'w',
-  CommandGetValue = 'r',
-  CommandSetMax = 'm',
-  CommandSetMin = '0',
+	CommandStepUp = 'u',
+	CommandStepDown = 'd',
+	CommandSetValue = 'w',
+	CommandGetValue = 'r',
+	CommandSetMax = 'm',
+	CommandSetMin = '0',
 };
 
 // We receive from the serial either commands or values,
@@ -34,7 +36,7 @@ SoftSerial serial(RX_PIN, TX_PIN);
 
 void setup()
 {
-	serial.begin(9600);
+	serial.begin(BAUD_RATE);
 	pinMode(PWM_PIN, OUTPUT);
 	analogWrite(PWM_PIN, value);
 }

--- a/luxmart-attiny85.ino
+++ b/luxmart-attiny85.ino
@@ -8,6 +8,16 @@
 int value = 0;
 const int step = 10;
 
+enum Command
+{
+  CommandStepUp = 'u',
+  CommandStepDown = 'd',
+  CommandSetValue = 'w',
+  CommandGetValue = 'r',
+  CommandSetMax = 'm',
+  CommandSetMin = '0',
+};
+
 // We receive from the serial either commands or values,
 // because we allow user to directly specify a value of PWM level.
 enum CommandMode
@@ -40,33 +50,33 @@ void loop()
 			switch (rc)
 			{
 				// Keys for incrementing and decrementing by a fixed step
-			case 'u' :
+			case CommandStepUp :
 				value += step;
 				value = min(255, value);
 				analogWrite(PWM_PIN, value);
 				break;
-			case 'd' :
+			case CommandStepDown :
 				value -= step;
 				value = max(0, value);
 				analogWrite(PWM_PIN, value);
 				break;
 				// Key for setting a specific value
-			case 'w':
+			case CommandSetValue :
 				// Switch serial interpretation to value mode.
 				mode = ReceiveValue;
 				break;
 				// Key for reading the value
-			case 'r':
+			case CommandGetValue :
 				// Indicate to the user that a value is coming.
 				serial.write('v');
 				serial.write(value);
 				break;
 				// Keys for setting to minimum and maximum value
-			case 'm' :
+			case CommandSetMax :
 				value = 255;
 				analogWrite(PWM_PIN, value);
 				break;
-			case '0' :
+			case CommandSetMin :
 				value = 0;
 				analogWrite(PWM_PIN, value);
 				break;

--- a/test/SoftSerial.h
+++ b/test/SoftSerial.h
@@ -1,10 +1,16 @@
 #ifndef SOFT_SERIAL_H
 #define SOFT_SERIAL_H
 
+#include <cassert>
+#include <mutex>
+#include <queue>
 #include <stdint.h>
 
 class SoftSerial
 {
+	std::mutex mtx;
+	std::queue<uint8_t> input, output;
+
 public :
 
 	SoftSerial(int rx, int tx)
@@ -17,16 +23,39 @@ public :
 	
 	bool available()
 	{
-		return true;
+		std::scoped_lock lock{mtx};
+		return !input.empty();
 	}
 	
 	int read()
 	{
-		return 0;
+		std::scoped_lock lock{mtx};
+		assert(!input.empty());
+		int result = input.front();
+		input.pop();
+		return result;
 	}
 	
 	void write(uint8_t byte)
 	{
+		std::scoped_lock lock{mtx};
+		output.push(byte);
+	}
+	
+	void put(int value)
+	{
+		std::scoped_lock lock{mtx};
+		input.push(value);
+	}
+	
+	bool get(char* value)
+	{
+		std::scoped_lock lock{mtx};
+		if (output.empty()) return false;
+		
+		*value = output.front();
+		output.pop();
+		return true;
 	}
 };
 

--- a/test/SoftSerial.h
+++ b/test/SoftSerial.h
@@ -1,0 +1,34 @@
+#ifndef SOFT_SERIAL_H
+#define SOFT_SERIAL_H
+
+#include <stdint.h>
+
+class SoftSerial
+{
+public :
+
+	SoftSerial(int rx, int tx)
+	{
+	}
+
+	void begin(int baudrate)
+	{
+	}
+	
+	bool available()
+	{
+		return true;
+	}
+	
+	int read()
+	{
+		return 0;
+	}
+	
+	void write(uint8_t byte)
+	{
+	}
+};
+
+#endif // SOFT_SERIAL_H
+

--- a/test/TinyPinChange.h
+++ b/test/TinyPinChange.h
@@ -1,0 +1,19 @@
+#ifndef TINY_PIN_CHANGE_H
+#define TINY_PIN_CHANGE_H
+
+#define OUTPUT 0
+
+#include <algorithm>
+
+using namespace std;
+
+void pinMode(int pin, int mode)
+{
+}
+
+void analogWrite(int pin, int value)
+{
+}
+
+#endif // TINY_PIN_CHANGE_H
+

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,6 +1,68 @@
 #include "luxmart-attiny85.ino"
 
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+const std::string putCommands[] =
+{
+	"r",
+	"a",
+	"aa",
+	"dd",
+	"aaa",
+	"m0",
+	"0m",
+	"wy",
+	"wxwywzw\x2a"
+	"xyz"
+	"r"
+};
+
 int main(int argc, char* argv[])
 {
+	std::thread loopThread([]()
+	{
+		setup();
+
+		while (1)
+		{
+			loop();
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		}
+	});
+
+	std::thread serialPutThread([]()
+	{
+		for (auto& cmd : putCommands)
+		{
+			for (const char& ch : cmd)
+			{
+				serial.put(ch);
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			}
+		}
+	});
+
+	std::thread serialGetThread([]()
+	{
+		while (1)
+		{
+			char ch;
+			if (serial.get(&ch))
+			{
+				if (ch == 'v')
+					std::cout << 'v';
+				else
+					std::cout << "0x" << hex << static_cast<int>(ch) << std::endl;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		}
+	});
+
+	loopThread.join();
+	serialPutThread.join();
+	serialGetThread.join();
+
 	return 0;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,5 +1,10 @@
+// This test is checking the ATTiny85 firmware on a development machine.
+// We create a minimum environment for the firmware to emulate the serial
+// communication.
+
 #include "luxmart-attiny85.ino"
 
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -19,13 +24,17 @@ const std::string putCommands[] =
 	"r"
 };
 
+const char getValues[] = { '\x0', '\x2a' };
+
 int main(int argc, char* argv[])
 {
-	std::thread loopThread([]()
+	std::atomic<bool> shutdown = false;
+
+	std::thread loopThread([&shutdown]()
 	{
 		setup();
 
-		while (1)
+		while (!shutdown)
 		{
 			loop();
 			std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -46,6 +55,8 @@ int main(int argc, char* argv[])
 
 	std::thread serialGetThread([]()
 	{
+		unsigned int ivalue = 0;
+
 		while (1)
 		{
 			char ch;
@@ -54,15 +65,33 @@ int main(int argc, char* argv[])
 				if (ch == 'v')
 					std::cout << 'v';
 				else
+				{					
+					auto ch_expected = getValues[ivalue++];
+					if (ch != ch_expected)
+					{
+						std::cerr << "Unexpected output value: got " << hex << static_cast<int>(ch) <<
+							", expected " << hex << static_cast<int>(ch_expected) << std::endl;
+						exit(-2);
+					}
+					
 					std::cout << "0x" << hex << static_cast<int>(ch) << std::endl;
+
+					if (ivalue >= sizeof(getValues)) return;
+				}
 			}
+
 			std::this_thread::sleep_for(std::chrono::milliseconds(10));
 		}
 	});
 
-	loopThread.join();
+	// First wait for all inputs to be consumed.
 	serialPutThread.join();
-	serialGetThread.join();
 
+	// Next, wait for all expected output.
+	serialGetThread.join();
+	
+	// Finally, shut down the loop.
+	shutdown = true;
+	loopThread.join();
 	return 0;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,0 +1,6 @@
+#include "luxmart-attiny85.ino"
+
+int main(int argc, char* argv[])
+{
+	return 0;
+}


### PR DESCRIPTION
Hi @ognjenMarinkovic27 ,

This PR proposes providing support for both flavors of PWM control commands: step-based and direct value specification. We may want to switch between them for different products, so why not to keep both, if they are not in conflict with each other?

I'm also adding a test case. The test case is generic, meaning that it does not require ATTiny85 or Arduino, and could be deployed just on a regular laptop or desktop. The test has revealed that having `serial.read()` in the write value command is not a good idea. I don't know how SoftSerial implementation works, but in general doing `serial.read()` not prepended by `serial.available()` is UB. For this reason, I've changed the serial parsing code to handle the values separately.

Please let me know what you think. If looks good to you, please merge and make the testing scenario more meaningful. Ideally, we would want `putCommands` and `getValues` content to test thoroughly all commands that we support. Having such testing is a good sign for our customers, that we are serious about a good product development. 